### PR TITLE
Enhance Job Messages in Datasets Details page

### DIFF
--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -95,8 +95,8 @@ function updateJob(fromProvider) {
                                 [{{ index }}]
                                 <ul>
                                     <li v-for="(value, name, index) in message" :key="index">
-                                        <strong>{{ name }}</strong>
-                                        : {{ value }}
+                                        <strong>{{ name }}:</strong>
+                                        {{ value }}
                                     </li>
                                 </ul>
                             </li>

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -29,8 +29,8 @@ const runTime = computed(() =>
 const jobIsTerminal = computed(() => job.value && !JOB_STATES_MODEL.NON_TERMINAL_STATES.includes(job.value.state));
 
 const metadataDetail = ref({
-    exit_code:
-        "Tools may use exit codes to indicate specific execution errors. Many programs use 0 to indicate success and non-zero exit codes to indicate errors. Galaxy allows each tool to specify exit codes that indicate errors. https://docs.galaxyproject.org/en/master/dev/schema.html#tool-stdio-exit-code",
+    exit_code: `Tools may use exit codes to indicate specific execution errors. Many programs use 0 to indicate success and non-zero exit codes to indicate errors. Galaxy allows each tool to specify exit codes that indicate errors. https://docs.galaxyproject.org/en/master/dev/schema.html#tool-stdio-exit-code`,
+    error_level: `NO_ERROR = 0</br>LOG = 1</br>QC = 1.1</br>WARNING = 2</br>FATAL = 3</br>FATAL_OOM = 4</br>MAX = 4`,
 });
 
 function updateJob(fromProvider) {
@@ -114,7 +114,7 @@ function filterMetadata(jobMessages) {
                                 <li v-for="(value, name, i) in message" :key="i">
                                     <span
                                         v-if="metadataDetail[name]"
-                                        v-b-tooltip.hover
+                                        v-b-tooltip.html
                                         class="tooltipJobInfo"
                                         :title="metadataDetail[name]"
                                         ><strong>{{ name }}:</strong></span

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -28,6 +28,11 @@ const runTime = computed(() =>
 
 const jobIsTerminal = computed(() => job.value && !JOB_STATES_MODEL.NON_TERMINAL_STATES.includes(job.value.state));
 
+const metadataDetail = ref({
+    exit_code:
+        "Tools may use exit codes to indicate specific execution errors. Many programs use 0 to indicate success and non-zero exit codes to indicate errors. Galaxy allows each tool to specify exit codes that indicate errors. https://docs.galaxyproject.org/en/master/dev/schema.html#tool-stdio-exit-code",
+});
+
 function updateJob(fromProvider) {
     job.value = fromProvider;
 }
@@ -107,7 +112,14 @@ function filterMetadata(jobMessages) {
                                     <u>Job Message {{ m + 1 }}:</u>
                                 </div>
                                 <li v-for="(value, name, i) in message" :key="i">
-                                    <strong>{{ name }}:</strong>
+                                    <span
+                                        v-if="metadataDetail[name]"
+                                        v-b-tooltip.hover
+                                        class="tooltipJobInfo"
+                                        :title="metadataDetail[name]"
+                                        ><strong>{{ name }}:</strong></span
+                                    >
+                                    <strong v-else>{{ name }}:</strong>
                                     {{ value }}
                                 </li>
                                 <hr v-if="m + 1 < job.job_messages.length" />
@@ -133,3 +145,10 @@ function filterMetadata(jobMessages) {
         </table>
     </div>
 </template>
+
+<style scoped>
+.tooltipJobInfo {
+    text-decoration-line: underline;
+    text-decoration-style: dashed;
+}
+</style>

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -56,7 +56,7 @@
                     <td>Job Messages</td>
                     <td>
                         <ul style="padding-left: 15px; margin-bottom: 0px">
-                            <li v-for="(message, index) in job.job_messages" :key="index">{{ message }}</li>
+                            <li v-for="(message, index) in job.job_messages" :key="index"><pre>{{ message }}</pre></li>
                         </ul>
                     </td>
                 </tr>

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -31,6 +31,17 @@ const jobIsTerminal = computed(() => job.value && !JOB_STATES_MODEL.NON_TERMINAL
 function updateJob(fromProvider) {
     job.value = fromProvider;
 }
+
+function filterMetadata(jobMessages) {
+    return jobMessages.map((item) => {
+        return Object.entries(item).reduce((acc, [key, value]) => {
+            if (value) {
+                acc[key] = value;
+            }
+            return acc;
+        }, {});
+    });
+}
 </script>
 
 <template>
@@ -91,15 +102,16 @@ function updateJob(fromProvider) {
                     <td>Job Messages</td>
                     <td>
                         <ul v-if="Array.isArray(job.job_messages)" class="pl-2 mb-0">
-                            <li v-for="(message, index) in job.job_messages" :key="index">
-                                [{{ index }}]
-                                <ul>
-                                    <li v-for="(value, name, index) in message" :key="index">
-                                        <strong>{{ name }}:</strong>
-                                        {{ value }}
-                                    </li>
-                                </ul>
-                            </li>
+                            <div v-for="(message, m) in filterMetadata(job.job_messages)" :key="m">
+                                <div v-if="job.job_messages.length > 1">
+                                    <u>Job Message {{ m + 1 }}:</u>
+                                </div>
+                                <li v-for="(value, name, i) in message" :key="i">
+                                    <strong>{{ name }}:</strong>
+                                    {{ value }}
+                                </li>
+                                <hr v-if="m + 1 < job.job_messages.length" />
+                            </div>
                         </ul>
                         <div v-else>
                             {{ job.job_messages }}

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -55,7 +55,7 @@
                 <tr v-if="job && job.job_messages && job.job_messages.length > 0" id="job-messages">
                     <td>Job Messages</td>
                     <td>
-                        <ul style="padding-left: 15px; margin-bottom: 0px">
+                        <ul v-if="Array.isArray(job.job_messages)" class="pl-2 mb-0">
                             <li v-for="(message, index) in job.job_messages" :key="index">
                                 [{{ index }}]
                                 <ul>
@@ -66,6 +66,9 @@
                                 </ul>
                             </li>
                         </ul>
+                        <div v-else>
+                            {{ job.job_messages }}
+                        </div>
                     </td>
                 </tr>
                 <slot></slot>

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -56,7 +56,15 @@
                     <td>Job Messages</td>
                     <td>
                         <ul style="padding-left: 15px; margin-bottom: 0px">
-                            <li v-for="(message, index) in job.job_messages" :key="index"><pre>{{ message }}</pre></li>
+                            <li v-for="(message, index) in job.job_messages" :key="index">
+                                [{{ index }}]
+                                <ul>
+                                    <li v-for="(value, name, index) in message" :key="index">
+                                        <strong>{{ name }}</strong>
+                                        : {{ value }}
+                                    </li>
+                                </ul>
+                            </li>
                         </ul>
                     </td>
                 </tr>


### PR DESCRIPTION
**Branch source information.** Relocated from Galaxy main's repo: #[17154](https://github.com/galaxyproject/galaxy/pull/17154) to point to base branch's repo which more clearly indicates the changes made by author. (For comments to original @bernt-matthias branch, visit this PR #[17016](https://github.com/galaxyproject/galaxy/pull/17016)  - Cc: jmchilton)

_(images updated: 2024.01.10)_
![screen demo v2 Error_Level](https://github.com/bernt-matthias/galaxy/assets/3672779/e7989094-2251-4490-9677-140ad27dbe78)
![screen demo v2 Exit_Code](https://github.com/bernt-matthias/galaxy/assets/3672779/f474e0c5-1967-486e-b124-83c4b1f6f838)
_Change request includes: (1) replacing non-formatted Object string output to bulleted HTML list for "Job Messages" output (2) adding Bootstrap-Vue Tooltip on hover. (3) preventing Job Messages' Metadata from displaying when `null`_ 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
